### PR TITLE
[#7] Environment variable as testrail config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [x] Static status comments on all the scenarios 
 - [x] Support for RSpec `shared examples` 
 - [x] Disable `testrail-rspec` execution on-demand
+- [x] Support for environment variables to pass testrail config values
 
 ## Installation
 
@@ -152,7 +153,7 @@ end
     ```
     Set, `clean_testrun: false` if you don't want to clean the existing test runs; but this keyword is optional.
 
-6. To skip specific test-runs from deletion, when `clean_testrun` is set `true`
+6. Skip specific test-runs from deletion: set `clean_testrun: true` & `skip_testrun_ids: value, ...`
     ```yaml
     testrail:
       url: https://your_url.testrail.io/
@@ -165,7 +166,7 @@ end
     ```
     Here, `skip_testrun_ids: value` is optional.
 
-7. To disable `testrail-rspec` execution 
+7. Disable `testrail-rspec` execution: set `allow: yes` 
     ```yaml
     testrail:
       url: https://your_url.testrail.io/
@@ -174,7 +175,20 @@ end
       run_id: 111
       allow: no
     ```
-    Here, `skip_testrun_ids: value` is optional.
+    Here, `allow: yes` is optional. 
+
+8. Use Environment variables to pass testrail config values 
+    ```yaml
+    testrail:
+      url: ENV['URL']
+      user: ENV['TESTRAIL_USER']
+      password: ENV['TESTRAIL_PASSWORD']
+      run_id: ENV['RUN_ID']
+      clean_testrun: false
+      project_id: 10
+      suite_id: 110
+    ```
+    Example, `rake ./demo_spec.rb TESTRAIL_USER=your@email.com TESTRAIL_PASSWORD=****** RUN_ID=564 URL=https://your_url.testrail.io/` 
 
 #### Hooks
 

--- a/lib/testrail-rspec/update-testrails.rb
+++ b/lib/testrail-rspec/update-testrails.rb
@@ -9,6 +9,14 @@ module TestrailRSpec
 
       if File.exist? './testrail_config.yml'
         @config = YAML.load_file("./testrail_config.yml")['testrail']
+
+        @config = @config.transform_values do |e|
+          if e.class != Integer && e.to_s.include?('ENV[')
+            eval(e)
+          else
+            e
+          end
+        end
         raise 'TestRail configuration file not loaded successfully' if @config.nil?
       else
         raise 'TestRail configuration file is required'

--- a/lib/testrail-rspec/version.rb
+++ b/lib/testrail-rspec/version.rb
@@ -1,3 +1,3 @@
 module TestrailRspec
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end


### PR DESCRIPTION
Added simple condition to accept config through Environment variables
- no changes to be made for the existing users 
- config is made two way: `env. variable` as well as `default value` in the config file
```
      url: ENV['URL']
      user: your@mail.com
      password: ENV['TESTRAIL_USER']
      run_id: ENV['RUN_ID']
      clean_testrun: false
      project_id: 10
      suite_id: 110
```

@Ilia-ab I really thank you for the awesome #1 pull request, which I took as a base to do this. I just changed the way it was written to cover the above two scenarios. 